### PR TITLE
Add CRL partitioning implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # llmtraining
+
+This repository contains Go examples demonstrating how to optimize handling of Certificate Revocation Lists (CRLs) in enterprise PKI environments.
+
+## CRL Partitioning Example
+
+`crl_partitioning.go` shows a basic approach to partitioning CRLs by certificate serial number prefix. The program fetches the appropriate CRL segment based on the serial number and checks whether the certificate is revoked.
+
+### Usage
+
+1. Build the program:
+
+   ```bash
+   go build crl_partitioning.go
+   ```
+
+2. Run the program with the base URL where CRL partitions are hosted and the certificate serial number:
+
+   ```bash
+   ./crl_partitioning https://crl.example.com/ ab12cd34
+   ```
+
+The program outputs whether the certificate is revoked according to the fetched CRL partition.
+

--- a/crl_partitioning.go
+++ b/crl_partitioning.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// fetchCRL downloads and parses a CRL from the given URL.
+func fetchCRL(url string) (*pkix.CertificateList, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch CRL: %s", resp.Status)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	// Attempt to decode PEM if needed
+	if p, _ := pem.Decode(data); p != nil {
+		data = p.Bytes
+	}
+	crl, err := x509.ParseCRL(data)
+	if err != nil {
+		return nil, err
+	}
+	return crl, nil
+}
+
+// checkRevocation fetches the CRL partition based on serial prefix and checks if the serial is revoked.
+func checkRevocation(serial, baseURL string) (bool, error) {
+	serial = strings.TrimPrefix(serial, "0x")
+	if len(serial) < 2 {
+		return false, fmt.Errorf("serial too short")
+	}
+	prefix := strings.ToLower(serial[:2])
+	url := fmt.Sprintf("%s/%s.crl", strings.TrimRight(baseURL, "/"), prefix)
+	crl, err := fetchCRL(url)
+	if err != nil {
+		return false, err
+	}
+	for _, revoked := range crl.TBSCertList.RevokedCertificates {
+		if revoked.SerialNumber.String() == strings.TrimLeft(serial, "0") {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <baseCRLURL> <serial>\n", os.Args[0])
+		os.Exit(1)
+	}
+	baseURL := os.Args[1]
+	serial := os.Args[2]
+	revoked, err := checkRevocation(serial, baseURL)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+	if revoked {
+		fmt.Println("certificate is revoked")
+	} else {
+		fmt.Println("certificate is not revoked")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module example.com/crlpartition
+
+go 1.23.8


### PR DESCRIPTION
## Summary
- add a Go module for examples
- implement a `crl_partitioning.go` sample showing how to fetch a CRL partition and check for revocation
- document usage in README

## Testing
- `go build crl_partitioning.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68493f9002e0832b9ac5c653efdbbb81