### PR TITLE
Add Cryptolang RL engine documentation and tooling

### DIFF
--- a/cryptolang/docs/ai/CRYPTOLANG_RL_ENGINE.md
+++ b/cryptolang/docs/ai/CRYPTOLANG_RL_ENGINE.md
@@ -1,0 +1,329 @@
+# 🧠 CRYPTOLANG_RL_ENGINE.md  
+### Reinforcement Learning Code Optimizer for Cryptolang
+
+---
+
+## 1. Purpose
+
+The **Cryptolang RL Engine** is a self-improving reinforcement-learning (RL) framework designed to autonomously enhance the **Cryptolang compiler, runtime, and language artifacts**.  
+It uses a compact **Low-Rank Value Representation (LRVR)** to learn relationships between code modifications and their impact on compilation speed, CPU efficiency, and runtime stability.
+
+This document defines:
+
+1. The full reinforcement-learning configuration (`rl_config.json`),  
+2. The unified Codex/GPT-compatible optimization prompt,  
+3. The local runtime skeleton (`rl_engine.go`) to drive the learning loop.
+
+---
+
+## 2. Project Context
+
+**Project:** Cryptolang  
+**Organization:** Schneider Electric  
+**Author:** Frédéric Aimé  
+**Primary Goal:** Generate progressively optimized compiler, runtime, and marshaller code — plus regenerated documentation, SBOM, and OpenAPI schemas.  
+**Iterations:** 10  
+**Focus Dimensions:**  
+- Compiler speed  
+- Memory footprint  
+- CPU utilization  
+- Error rate  
+
+---
+
+## 3. RL + LRVR Architecture Overview
+
+┌───────────────────────────────┐
+│ cryptolang/ source code │
+├───────────────────────────────┤
+│ rl_engine.go │
+│ ├─ loads rl_config.json │
+│ ├─ feeds code + metrics → │
+│ │ Codex/GPT prompt │
+│ ├─ receives updated code │
+│ └─ logs reward evolution │
+├───────────────────────────────┤
+│ rl_config.json │
+│ ├─ reward coefficients │
+│ ├─ metric schema │
+│ ├─ LRVR parameters │
+│ └─ safety rules │
+└───────────────────────────────┘
+
+css
+Copy code
+
+The RL engine executes up to 10 learning cycles.  
+Each cycle:
+1. Generates a code improvement proposal.  
+2. Evaluates simulated metrics.  
+3. Computes reward Rᵢ.  
+4. Updates latent matrices Uₛ and Vₐ.  
+5. Logs convergence data and merges accepted improvements.
+
+---
+
+## 4. `rl_config.json`
+
+```json
+{
+  "version": "1.0",
+  "project": "Cryptolang",
+  "description": "Reinforcement-Learning and Low-Rank Value Representation framework for Cryptolang compiler and runtime generation",
+  "author": "Frédéric Aimé",
+  "organization": "Schneider Electric",
+  "parameters": {
+    "iterations": 10,
+    "rank": 4,
+    "learning_rate": 0.1,
+    "stop_conditions": {
+      "min_improvement_percent": 1.0,
+      "plateau_tolerance": 2
+    }
+  },
+  "reward_function": {
+    "formula": "Reward_i = 0.4*(-compile_time_ms_norm) + 0.3*(1 - error_rate) + 0.3*(-cpu_util%)",
+    "description": "Higher reward indicates faster, safer, and leaner compiler/runtime."
+  },
+  "metric_schema": {
+    "metrics": [
+      "compile_time_ms",
+      "mem_peak_mb",
+      "cpu_util_percent",
+      "error_rate"
+    ],
+    "normalization": {
+      "compile_time_ms": "lower_is_better",
+      "mem_peak_mb": "lower_is_better",
+      "cpu_util_percent": "lower_is_better",
+      "error_rate": "lower_is_better"
+    },
+    "expected_improvement_targets": {
+      "compile_time_ms": -20,
+      "mem_peak_mb": -10,
+      "cpu_util_percent": -15
+    }
+  },
+  "lrvr": {
+    "rank": 4,
+    "eta": 0.1,
+    "latent_factor_labels": [
+      "parser_latency",
+      "memory_efficiency",
+      "crypto_provider_overhead",
+      "runtime_stability"
+    ],
+    "update_rule": "U_s[i+1] = U_s[i] + η*(R_i - Q_i)*V_a[i]; V_a[i+1] = V_a[i] + η*(R_i - Q_i)*U_s[i]"
+  },
+  "output": {
+    "sections": [
+      "iteration_summaries",
+      "reward_evolution_table",
+      "lrvr_latent_dynamics",
+      "final_optimized_code",
+      "language_artifact_diffs"
+    ]
+  },
+  "safety": {
+    "constraints": [
+      "No insecure cryptographic primitives.",
+      "All generated providers must pass self-tests.",
+      "Preserve licensing and SBOM integrity."
+    ]
+  }
+}
+5. Unified Codex / GPT Prompt
+markdown
+Copy code
+# 🧠 CRYPTOLANG RL CODE OPTIMIZER (One-Shot Prompt)
+
+You are the **Cryptolang Reinforcement-Learning Code Generator**.  
+Your mission: improve the Cryptolang compiler, runtime, and marshaller components through **10 RL iterations**, guided by **Low-Rank Value Representation (LRVR)**.
+
+---
+
+### 1️⃣ Environment
+- Repository: `cryptolang/`
+- Config: `rl_config.json`
+- Reward = function(compile_time, CPU%, memory, error_rate)
+- Iterations: 10 or stop after 2 plateaued improvements (< 1 %)
+
+---
+
+### 2️⃣ Iteration Workflow
+For each iteration i = 1…10:
+
+1. Analyze previous metrics and reward Rᵢ₋₁.  
+2. Propose one atomic, compilable code change improving efficiency or correctness.  
+3. Output a **code diff** (or replacement) with explanation.  
+4. Simulate realistic new metrics within ±30 %.  
+5. Compute new reward Rᵢ and LRVR update.  
+6. Interpret latent factors (parser_latency, memory_efficiency, etc.).  
+
+---
+
+### 3️⃣ LRVR Logic
+Qᵢ = Uₛ[i] · Vₐ[i]^T
+Uₛ[i+1] = Uₛ[i] + η (Rᵢ − Qᵢ) Vₐ[i]
+Vₐ[i+1] = Vₐ[i] + η (Rᵢ − Qᵢ) Uₛ[i]
+
+yaml
+Copy code
+η = 0.1, rank = 4.
+
+---
+
+### 4️⃣ Output per Iteration
+**Iteration i**  
+- **Improvement:** short description  
+- **Code Diff:** fenced block  
+- **Simulated Metrics:** compile_time_ms = …, cpu% = …, mem = …, error_rate = …  
+- **Rewardᵢ = … | ΔReward = …**  
+- **Latent Factors:** summarized Uₛ[i], Vₐ[i]  
+- **Hypothesis:** one-sentence rationale  
+
+After last iteration or convergence, output:
+
+#### 📈 Convergence Table  
+| Iter | Compile (ms) | CPU (%) | Mem (MB) | Err Rate | Reward | ΔR |  
+|------|--------------|---------|-----------|-----------|---------|----|  
+
+#### 🔬 LRVR Latent Dynamics  
+| Iter | Qᵢ | ΔQ | Top Factors | Interpretation |  
+
+#### ✅ Final Optimized Code  
+Full merged implementation of the improved compiler or runtime file.
+
+#### 📘 Language Artifact Diffs  
+Summaries of grammar or marshaller updates.
+
+---
+
+### 5️⃣ Rules
+- Modify **Cryptolang code only**.  
+- Ensure the code compiles and passes tests.  
+- Never weaken cryptographic primitives.  
+- Preserve documentation and licensing.  
+- Output the full multi-iteration report in one response.
+
+**Begin Cryptolang RL optimization now.**
+6. Runtime Skeleton (rl_engine.go)
+go
+Copy code
+// rl_engine.go – Local RL Driver for Cryptolang
+package main
+
+import (
+    "encoding/json"
+    "fmt"
+    "math/rand"
+    "os"
+    "time"
+)
+
+type Config struct {
+    Parameters struct {
+        Iterations int `json:"iterations"`
+    } `json:"parameters"`
+}
+
+type Metrics struct {
+    CompileTime float64
+    CPU         float64
+    Mem         float64
+    ErrorRate   float64
+    Reward      float64
+}
+
+func reward(m Metrics) float64 {
+    return 0.4*(-m.CompileTime/100.0) + 0.3*(1.0 - m.ErrorRate) + 0.3*(-m.CPU)
+}
+
+func simulateMetrics(prev Metrics) Metrics {
+    noise := func(v float64, pct float64) float64 {
+        delta := (rand.Float64()*2 - 1) * pct / 100
+        return v * (1 + delta)
+    }
+    m := Metrics{}
+    m.CompileTime = noise(prev.CompileTime, 20)
+    m.CPU = noise(prev.CPU, 15)
+    m.Mem = noise(prev.Mem, 10)
+    m.ErrorRate = noise(prev.ErrorRate, 5)
+    m.Reward = reward(m)
+    return m
+}
+
+func main() {
+    rand.Seed(time.Now().UnixNano())
+
+    file, _ := os.ReadFile("rl_config.json")
+    var cfg Config
+    json.Unmarshal(file, &cfg)
+
+    base := Metrics{CompileTime: 108, CPU: 57.3, Mem: 92, ErrorRate: 0.003}
+    base.Reward = reward(base)
+    fmt.Printf("Iter 0 → Reward %.3f\n", base.Reward)
+
+    current := base
+    for i := 1; i <= cfg.Parameters.Iterations; i++ {
+        next := simulateMetrics(current)
+        delta := next.Reward - current.Reward
+        fmt.Printf("Iter %d → Reward %.3f (Δ%.3f)\n", i, next.Reward, delta)
+        current = next
+        time.Sleep(150 * time.Millisecond)
+    }
+
+    fmt.Println("Simulation complete. Review logs for convergence behavior.")
+}
+This lightweight runtime:
+
+Loads rl_config.json.
+
+Simulates metric evolution for 10 iterations.
+
+Computes and prints rewards.
+
+Can be extended to actually call Codex/GPT APIs for live optimization.
+
+7. Deployment & Usage
+Place these files in /cryptolang/docs/ai/:
+
+CRYPTOLANG_RL_ENGINE.md
+
+rl_config.json
+
+rl_engine.go
+
+Compile the local engine:
+
+bash
+Copy code
+```
+go run rl_engine.go
+```
+Inspect output for reward convergence.
+
+Integrate Codex/GPT API calls inside rl_engine.go to send the unified prompt and receive new code diffs automatically.
+
+8. Future Extensions
+DomainNext Step
+DataConnect live compiler metrics instead of simulation.
+PersistenceLog all iterations in /reports/iteration_X.json.
+SecurityValidate generated providers against Cryptolang self-test suite.
+VisualizationAdd Grafana/HTML dashboard for latent factor evolution.
+
+9. Summary
+The Cryptolang RL Engine makes the language self-optimizing:
+
+Reinforcement learning loop (10 iterations)
+
+LRVR compression for fast, stable convergence
+
+Deterministic reward schema (compile time, CPU, memory, errors)
+
+Fully Codex/GPT-compatible prompt
+
+Local Go runtime for reproducible experiments
+
+“The compiler that learns itself — Cryptolang’s next evolutionary step.”
+— Frédéric Aimé (2025)

--- a/cryptolang/docs/ai/rl_config.json
+++ b/cryptolang/docs/ai/rl_config.json
@@ -1,0 +1,66 @@
+{
+  "version": "1.0",
+  "project": "Cryptolang",
+  "description": "Reinforcement-Learning and Low-Rank Value Representation framework for Cryptolang compiler and runtime generation",
+  "author": "Frédéric Aimé",
+  "organization": "Schneider Electric",
+  "parameters": {
+    "iterations": 10,
+    "rank": 4,
+    "learning_rate": 0.1,
+    "stop_conditions": {
+      "min_improvement_percent": 1.0,
+      "plateau_tolerance": 2
+    }
+  },
+  "reward_function": {
+    "formula": "Reward_i = 0.4*(-compile_time_ms_norm) + 0.3*(1 - error_rate) + 0.3*(-cpu_util%)",
+    "description": "Higher reward indicates faster, safer, and leaner compiler/runtime."
+  },
+  "metric_schema": {
+    "metrics": [
+      "compile_time_ms",
+      "mem_peak_mb",
+      "cpu_util_percent",
+      "error_rate"
+    ],
+    "normalization": {
+      "compile_time_ms": "lower_is_better",
+      "mem_peak_mb": "lower_is_better",
+      "cpu_util_percent": "lower_is_better",
+      "error_rate": "lower_is_better"
+    },
+    "expected_improvement_targets": {
+      "compile_time_ms": -20,
+      "mem_peak_mb": -10,
+      "cpu_util_percent": -15
+    }
+  },
+  "lrvr": {
+    "rank": 4,
+    "eta": 0.1,
+    "latent_factor_labels": [
+      "parser_latency",
+      "memory_efficiency",
+      "crypto_provider_overhead",
+      "runtime_stability"
+    ],
+    "update_rule": "U_s[i+1] = U_s[i] + η*(R_i - Q_i)*V_a[i]; V_a[i+1] = V_a[i] + η*(R_i - Q_i)*U_s[i]"
+  },
+  "output": {
+    "sections": [
+      "iteration_summaries",
+      "reward_evolution_table",
+      "lrvr_latent_dynamics",
+      "final_optimized_code",
+      "language_artifact_diffs"
+    ]
+  },
+  "safety": {
+    "constraints": [
+      "No insecure cryptographic primitives.",
+      "All generated providers must pass self-tests.",
+      "Preserve licensing and SBOM integrity."
+    ]
+  }
+}

--- a/cryptolang/docs/ai/rl_engine.go
+++ b/cryptolang/docs/ai/rl_engine.go
@@ -1,0 +1,65 @@
+// rl_engine.go – Local RL Driver for Cryptolang
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
+)
+
+type Config struct {
+	Parameters struct {
+		Iterations int `json:"iterations"`
+	} `json:"parameters"`
+}
+
+type Metrics struct {
+	CompileTime float64
+	CPU         float64
+	Mem         float64
+	ErrorRate   float64
+	Reward      float64
+}
+
+func reward(m Metrics) float64 {
+	return 0.4*(-m.CompileTime/100.0) + 0.3*(1.0-m.ErrorRate) + 0.3*(-m.CPU)
+}
+
+func simulateMetrics(prev Metrics) Metrics {
+	noise := func(v float64, pct float64) float64 {
+		delta := (rand.Float64()*2 - 1) * pct / 100
+		return v * (1 + delta)
+	}
+	m := Metrics{}
+	m.CompileTime = noise(prev.CompileTime, 20)
+	m.CPU = noise(prev.CPU, 15)
+	m.Mem = noise(prev.Mem, 10)
+	m.ErrorRate = noise(prev.ErrorRate, 5)
+	m.Reward = reward(m)
+	return m
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+
+	file, _ := os.ReadFile("rl_config.json")
+	var cfg Config
+	json.Unmarshal(file, &cfg)
+
+	base := Metrics{CompileTime: 108, CPU: 57.3, Mem: 92, ErrorRate: 0.003}
+	base.Reward = reward(base)
+	fmt.Printf("Iter 0 → Reward %.3f\n", base.Reward)
+
+	current := base
+	for i := 1; i <= cfg.Parameters.Iterations; i++ {
+		next := simulateMetrics(current)
+		delta := next.Reward - current.Reward
+		fmt.Printf("Iter %d → Reward %.3f (Δ%.3f)\n", i, next.Reward, delta)
+		current = next
+		time.Sleep(150 * time.Millisecond)
+	}
+
+	fmt.Println("Simulation complete. Review logs for convergence behavior.")
+}


### PR DESCRIPTION
## Summary
- add a comprehensive CRYPTOLANG_RL_ENGINE.md reference outlining the reinforcement-learning workflow
- provide the rl_config.json settings and Go-based rl_engine driver under docs/ai for local experimentation

## Testing
- go test ./...

------
https://chatgpt.com/codex/tasks/task_e_68fe28969290832b93299909f29ada5b